### PR TITLE
As OpenZeppelin changes their code, some unit tests in our code start to

### DIFF
--- a/test/affe.test.js
+++ b/test/affe.test.js
@@ -222,7 +222,7 @@ describe('Affe mit Waffe Unit Testing',  () => {
             const contractNoRole = await this.contract.connect(this.accounts[account.accNoRoles2.idx])
             await expect(contractNoRole.transferFrom(
                 this.accounts[account.accNoRoles1.idx].address, this.accounts[account.accNoRoles2.idx].address, tokenId))
-                .to.be.revertedWith('ERC721: transfer caller is not owner nor approved');
+                .to.be.revertedWith('ERC721: caller is not token owner nor approved');
         });
     });
 
@@ -251,7 +251,7 @@ describe('Affe mit Waffe Unit Testing',  () => {
             // (Note in the line below, even though 'ownerOf' is a read-only function, so we should not
             // need to 'connect', the 'to.be.reverdedWith' does not seem to work without a connection.)
             await expect(this.contract.connect(this.accounts[account.accNoRoles2.idx]).ownerOf(tokenId))
-                .to.be.revertedWith('ERC721: owner query for nonexistent token');
+                .to.be.revertedWith('ERC721: invalid token ID');
         });
 
         it('should not allow an account to burn a token they do not own', async () => {
@@ -263,7 +263,7 @@ describe('Affe mit Waffe Unit Testing',  () => {
             // Try to burn the token connected to the contract as someone who is not the token owner
             // expecting it to fail
             await expect(this.contract.connect(this.accounts[account.accNoRoles2.idx]).burn(tokenId))
-                .to.be.revertedWith('ERC721Burnable: caller is not owner nor approved');
+                .to.be.revertedWith('ERC721: caller is not token owner nor approved');
         });
     });
 
@@ -1203,13 +1203,13 @@ describe('Affe mit Waffe Unit Testing',  () => {
             // both versions of the functions separately.
             await expect(contractAsArbitraryAccount["safeTransferFrom(address,address,uint256)"]
                 (addressBorrower, accArbitraryAccount1.address, tokenId))
-                .to.be.revertedWith("ERC721: transfer caller is not owner nor approved");
+                .to.be.revertedWith("ERC721: caller is not token owner nor approved'");
             await expect(contractAsArbitraryAccount["safeTransferFrom(address,address,uint256,bytes)"]
                 (addressBorrower, accArbitraryAccount1.address, tokenId, []))
-                .to.be.revertedWith("ERC721: transfer caller is not owner nor approved");
+                .to.be.revertedWith("ERC721: caller is not token owner nor approved'");
             // Also try the regular transferFrom function    
             await expect(contractAsArbitraryAccount.transferFrom(addressBorrower, accArbitraryAccount1.address, tokenId))
-                .to.be.revertedWith("ERC721: transfer caller is not owner nor approved");
+                .to.be.revertedWith("ERC721: caller is not token owner nor approved'");
             // Expect ownership and balances to still be correct
             expect(await this.contract.ownerOf(tokenId)).to.equal(addressBorrower);
             expect(await this.contract.balanceOf(addressRightfulOwner)).to.equal(3);
@@ -1229,7 +1229,7 @@ describe('Affe mit Waffe Unit Testing',  () => {
             const contractAsArbitraryAccount = await this.contract.connect(accArbitraryAccount1);
             // Try to burn the token expecting to fail
             await expect(contractAsArbitraryAccount.burn(tokenId))
-                .to.be.revertedWith("ERC721Burnable: caller is not owner nor approved");
+                .to.be.revertedWith("ERC721: caller is not token owner nor approved'");
             // Expect ownership and balances to still be correct
             expect(await this.contract.ownerOf(tokenId)).to.equal(addressBorrower);
             expect(await this.contract.balanceOf(addressRightfulOwner)).to.equal(3);


### PR DESCRIPTION
fail. This commit updates the code so all the unit tests pass again.
Basically, it seems OpenZeppelin changed the working of some of the
errors that their contracts threw, as well as which contract in the
order of inheritance was throwing the error (eg. in the past
ERC721Burnable was throwing an error that ERC721 is now throwing.) So
our unit tests, when running, were expecting to find different error
messages. The error messages have been updated to match the latest
OpenZeppelin code and now the tests are passing again.